### PR TITLE
unity: settings: enable runInBackground

### DIFF
--- a/UltraStar Play/ProjectSettings/ProjectSettings.asset
+++ b/UltraStar Play/ProjectSettings/ProjectSettings.asset
@@ -76,7 +76,7 @@ PlayerSettings:
   androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 1
   Prepare IOS For Recording: 0


### PR DESCRIPTION
### What does this PR do?

This simply enables the `runInBackground` option for Unity, so that the game doesn't pause when it loses focus. This makes it have a sane behaviour that matches the original UltraStar as well.

### Motivation

I like to sometimes put UltraStar on my second monitor and sing along while doing other things, or briefly alt-tab to another window while a song is playing. Currently the game completely halts due to the Unity default settings and it's very jarring.

(If this is desired functionality, can we get it as an in-game setting instead?)

### Additional Notes

Unity docs link: https://docs.unity3d.com/ScriptReference/Application-runInBackground.html
